### PR TITLE
Fix for saving a partial address

### DIFF
--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -33,7 +33,11 @@ module Nylas
       def to_h(keys: attribute_definitions.keys)
         keys.each_with_object({}) do |key, casted_data|
           value = attribute_definitions[key].serialize(self[key])
-          casted_data[key] = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
+          if %i[street_address postal_code state city country].include?(key)
+            casted_data[key] = value || ""
+          else
+            casted_data[key] = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
+          end
         end
       end
 

--- a/spec/nylas/contact_spec.rb
+++ b/spec/nylas/contact_spec.rb
@@ -12,11 +12,22 @@ describe Nylas::Contact do
         '{ "type": "home", "email": "given@home.example.com" }], ' \
       '"im_addresses": [{ "type": "gtalk", "im_address": "given@gtalk.example.com" }],' \
       '"physical_addresses": [{ "format": "structured", "type": "work",' \
-        '"street_address": "123 N West St", "postal_code": "12345+0987", "state": "CA",' \
+        '"street_address": "123 N West St", "postal_code": "12345+0987", "city": "Los Angeles", "state": "CA",' \
         '"country": "USA" }],' \
       '"phone_numbers": [{ "type": "mobile", "number": "+1234567890" }], ' \
       '"web_pages": [{ "type": "profile", "url": "http://given.example.com" }],' \
       '"groups": [{"id": "di", "object": "dnwi", "account_id": "doiw", "name": "nfowie", "path": "fnien"}] ' \
+    "}"
+  end
+  let(:partial_address_json) do
+    '{ "id": "1234", "object": "contact", "account_id": "12345", ' \
+      '"given_name":"given", "middle_name": "middle", "surname": "surname", ' \
+      '"birthday": "1984-01-01", "suffix": "Jr.", "nickname": "nick", ' \
+      '"company_name": "company", "job_title": "title", ' \
+      '"manager_name": "manager", "office_location": "the office", ' \
+      '"physical_addresses": [{ "format": "structured", "type": "work",' \
+        '"street_address": "123 N West St", "postal_code": "", "city": "", "state": "",' \
+        '"country": "USA" }]' \
     "}"
   end
   let(:api) { FakeAPI.new }
@@ -111,12 +122,34 @@ describe Nylas::Contact do
                                   phone_numbers: [{ type: "mobile", number: "+1234567890" }],
                                   physical_addresses: [{ format: "structured", type: "work",
                                                          street_address: "123 N West St",
-                                                         postal_code: "12345+0987", state: "CA",
+                                                         postal_code: "12345+0987", city: "Los Angeles", state: "CA",
                                                          country: "USA" }],
                                   web_pages: [{ type: "profile", url: "http://given.example.com" }],
                                   groups: [{id: "di", object: "dnwi", account_id: "doiw", name: "nfowie", path: "fnien"}])
     end
+
+    it "serializes attributes correctly for a contact with a partial physical address" do
+      contact = described_class.from_json(partial_address_json, api: api)
+      expect(contact.to_h).to eql(id: "1234",
+                                  object: "contact",
+                                  account_id: "12345",
+                                  given_name: "given",
+                                  middle_name: "middle",
+                                  surname: "surname",
+                                  suffix: "Jr.",
+                                  nickname: "nick",
+                                  job_title: "title",
+                                  office_location: "the office",
+                                  manager_name: "manager",
+                                  birthday: "1984-01-01",
+                                  company_name: "company",
+                                  physical_addresses: [{ format: "structured", type: "work",
+                                                         street_address: "123 N West St",
+                                                         postal_code: "", city: "", state: "",
+                                                         country: "USA" }])
+    end
   end
+
   describe "#to_json" do
     it "returns a string of JSON" do
       contact = described_class.from_json(full_json, api: api)


### PR DESCRIPTION
Physical addresses require every part to be present, so we fill any missing parts with an empty string