### PR TITLE
Override save method to exclude the object field in when

### DIFF
--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -40,6 +40,19 @@ module Nylas
       read_only
     end
 
+    def save
+      result = if persisted?
+                 raise ModelNotUpdatableError, self unless updatable?
+
+                 payload = JSON.parse(attributes.serialize)
+                 payload["when"] = payload["when"].except("object")
+                 execute(method: :put, payload: payload.to_json, path: resource_path)
+               else
+                 create
+               end
+      attributes.merge(result)
+    end
+
     def rsvp(status, notify_participants:)
       rsvp = Rsvp.new(api: api, status: status, notify_participants: notify_participants,
                       event_id: id, account_id: account_id)


### PR DESCRIPTION
new gem version of 
https://github.com/nylas/nylas-ruby/blob/3.X-master/lib/event.rb#L19

because nylas events returned from the api can't be saved. they throw
```
400 BadRequest | application/json 100 bytes
Nylas::InvalidRequest: Event `when` cannot have an object attribute
```
due to some validation on the api.