### PR TITLE
Add address to physical address

### DIFF
--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -51,6 +51,7 @@ require_relative "nylas/message"
 require_relative "nylas/new_message"
 require_relative "nylas/raw_message"
 require_relative "nylas/thread"
+require_relative "nylas/tracking"
 require_relative "nylas/webhook"
 
 require_relative "nylas/native_authentication"
@@ -81,6 +82,7 @@ module Nylas
   Types.registry[:recurrence] = Types::ModelType.new(model: Recurrence)
   Types.registry[:thread] = Types::ModelType.new(model: Thread)
   Types.registry[:timespan] = Types::ModelType.new(model: Timespan)
+  Types.registry[:tracking] = Types::ModelType.new(model: Tracking)
   Types.registry[:web_page] = Types::ModelType.new(model: WebPage)
   Types.registry[:nylas_date] = NylasDateType.new
   Types.registry[:contact_group] = Types::ModelType.new(model: ContactGroup)

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -69,9 +69,9 @@ module Nylas
   Types.registry[:email_address] = Types::ModelType.new(model: EmailAddress)
   Types.registry[:event] = Types::ModelType.new(model: Event)
   Types.registry[:file] = Types::ModelType.new(model: File)
-  Types.registry[:folder] = Types::ModelType.new(model: Folder)
+  Types.registry[:folder] = Types::ContainerType.new(model: Folder)
   Types.registry[:im_address] = Types::ModelType.new(model: IMAddress)
-  Types.registry[:label] = Types::ModelType.new(model: Label)
+  Types.registry[:label] = Types::ContainerType.new(model: Label)
   Types.registry[:message] = Types::ModelType.new(model: Message)
   Types.registry[:message_headers] = MessageHeadersType.new
   Types.registry[:message_tracking] = Types::ModelType.new(model: MessageTracking)

--- a/lib/nylas/contact.rb
+++ b/lib/nylas/contact.rb
@@ -28,7 +28,6 @@ module Nylas
     attribute :office_location, :string
     attribute :notes, :string
     attribute :source, :string
-    attribute :web_page, :web_page
 
     has_n_of_attribute :groups, :contact_group
     has_n_of_attribute :emails, :email_address

--- a/lib/nylas/contact.rb
+++ b/lib/nylas/contact.rb
@@ -27,6 +27,7 @@ module Nylas
     attribute :manager_name, :string
     attribute :office_location, :string
     attribute :notes, :string
+    attribute :source, :string
     attribute :web_page, :web_page
 
     has_n_of_attribute :groups, :contact_group

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -28,6 +28,7 @@ module Nylas
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
+    has_n_of_attribute :file_ids, :string
     attribute :folder, :folder
     has_n_of_attribute :labels, :label
 

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -25,6 +25,7 @@ module Nylas
     attribute :body, :string
     attribute :starred, :boolean
     attribute :unread, :boolean
+    attribute :tracking, :tracking
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
@@ -33,8 +34,7 @@ module Nylas
     has_n_of_attribute :labels, :label
 
     def send!
-      save
-      execute(method: :post, path: "/send", payload: JSON.dump(draft_id: id, version: version))
+      execute(method: :post, path: "/send", payload: to_json)
     end
 
     def starred?

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -25,6 +25,12 @@ module Nylas
     attribute :title, :string
     attribute :when, :timespan
     attribute :original_start_time, :unix_timestamp
+    attr_reader :raw_json
+
+    def initialize(*args, &block)
+      super(*args, &block)
+      @raw_json = JSON.parse(to_json)
+    end
 
     def busy?
       busy

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -33,11 +33,7 @@ module Nylas
       def to_h(keys: attribute_definitions.keys)
         keys.each_with_object({}) do |key, casted_data|
           value = attribute_definitions[key].serialize(self[key])
-          if %i[street_address postal_code state city country].include?(key)
-            casted_data[key] = value || ""
-          else
-            casted_data[key] = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
-          end
+          casted_data[key] = defaulted_value(value)
         end
       end
 
@@ -47,6 +43,13 @@ module Nylas
 
       private def default_attributes
         attribute_definitions.keys.zip([]).to_h
+      end
+
+      private def defaulted_value(value)
+        result = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        result ||= [] if value.is_a?(Array)
+        result ||= "" unless [true, false].include?(value)
+        result
       end
     end
   end

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -33,7 +33,11 @@ module Nylas
       def to_h(keys: attribute_definitions.keys)
         keys.each_with_object({}) do |key, casted_data|
           value = attribute_definitions[key].serialize(self[key])
-          casted_data[key] = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
+          if %i[street_address postal_code state city country].include?(key)
+            casted_data[key] = value || ""
+          else
+            casted_data[key] = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
+          end
         end
       end
 

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -33,7 +33,7 @@ module Nylas
       def to_h(keys: attribute_definitions.keys)
         keys.each_with_object({}) do |key, casted_data|
           value = attribute_definitions[key].serialize(self[key])
-          casted_data[key] = defaulted_value(value)
+          casted_data[key] = value unless value.nil?
         end
       end
 
@@ -43,13 +43,6 @@ module Nylas
 
       private def default_attributes
         attribute_definitions.keys.zip([]).to_h
-      end
-
-      private def defaulted_value(value)
-        result = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
-        result ||= [] if value.is_a?(Array)
-        result ||= "" unless [true, false].include?(value)
-        result
       end
     end
   end

--- a/lib/nylas/physical_address.rb
+++ b/lib/nylas/physical_address.rb
@@ -10,5 +10,6 @@ module Nylas
     attribute :state, :string
     attribute :city, :string
     attribute :country, :string
+    attribute :address, :string
   end
 end

--- a/lib/nylas/tracking.rb
+++ b/lib/nylas/tracking.rb
@@ -1,0 +1,9 @@
+module Nylas
+  class Tracking
+    include Model::Attributable
+    attribute :links, :boolean
+    attribute :opens, :boolean
+    attribute :thread_replies, :boolean
+    attribute :payload, :string
+  end
+end

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -54,7 +54,7 @@ module Nylas
 
     class ContainerType < ModelType
       def serialize(object)
-        object.id
+        object&.id
       end
     end
 

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -52,6 +52,12 @@ module Nylas
       end
     end
 
+    class ContainerType < ModelType
+      def serialize(object)
+        object.id
+      end
+    end
+
     # Type for attributes that do not require casting/serializing/deserializing.
     class ValueType
       def cast(object)

--- a/spec/nylas/contact_spec.rb
+++ b/spec/nylas/contact_spec.rb
@@ -12,11 +12,22 @@ describe Nylas::Contact do
         '{ "type": "home", "email": "given@home.example.com" }], ' \
       '"im_addresses": [{ "type": "gtalk", "im_address": "given@gtalk.example.com" }],' \
       '"physical_addresses": [{ "format": "structured", "type": "work",' \
-        '"street_address": "123 N West St", "postal_code": "12345+0987", "state": "CA",' \
+        '"street_address": "123 N West St", "postal_code": "12345+0987", "city": "Los Angeles", "state": "CA",' \
         '"country": "USA" }],' \
       '"phone_numbers": [{ "type": "mobile", "number": "+1234567890" }], ' \
       '"web_pages": [{ "type": "profile", "url": "http://given.example.com" }],' \
       '"groups": [{"id": "di", "object": "dnwi", "account_id": "doiw", "name": "nfowie", "path": "fnien"}] ' \
+    "}"
+  end
+  let(:partial_address_json) do
+    '{ "id": "1234", "object": "contact", "account_id": "12345", ' \
+      '"given_name":"given", "middle_name": "middle", "surname": "surname", ' \
+      '"birthday": "1984-01-01", "suffix": "Jr.", "nickname": "nick", ' \
+      '"company_name": "company", "job_title": "title", ' \
+      '"manager_name": "manager", "office_location": "the office", ' \
+      '"physical_addresses": [{ "format": "structured", "type": "work",' \
+        '"street_address": "123 N West St", "postal_code": "", "city": "", "state": "",' \
+        '"country": "USA" }]' \
     "}"
   end
   let(:api) { FakeAPI.new }
@@ -111,12 +122,34 @@ describe Nylas::Contact do
                                   phone_numbers: [{ type: "mobile", number: "+1234567890" }],
                                   physical_addresses: [{ format: "structured", type: "work",
                                                          street_address: "123 N West St",
-                                                         postal_code: "12345+0987", state: "CA",
+                                                         postal_code: "12345+0987", city: "Los Angeles", state: "CA",
                                                          country: "USA" }],
                                   web_pages: [{ type: "profile", url: "http://given.example.com" }],
                                   groups: [{id: "di", object: "dnwi", account_id: "doiw", name: "nfowie", path: "fnien"}])
     end
+
+    it "serializes attributes correctly for a contact with a partial physical address" do
+      contact = described_class.from_json(partial_address_json, api: api)
+      expect(contact.to_h).to eql(id: "1234",
+                                  object: "contact",
+                                  account_id: "12345",
+                                  given_name: "given",
+                                  middle_name: "middle",
+                                  surname: "surname",
+                                  suffix: "Jr.",
+                                  nickname: "nick",
+                                  job_title: "title",
+                                  office_location: "the office",
+                                  manager_name: "manager",
+                                  birthday: "1984-01-01",
+                                  company_name: "company",
+                                  physical_addresses: [{ format: "structured", type: "work",
+                                                         street_address: "123 N West St",
+                                                         postal_code: "", city: "", state: "",
+                                                         country: "USA" }])
+    end
   end
+
   describe "#to_json" do
     it "returns a string of JSON" do
       contact = described_class.from_json(full_json, api: api)

--- a/spec/nylas/contact_spec.rb
+++ b/spec/nylas/contact_spec.rb
@@ -7,16 +7,14 @@ describe Nylas::Contact do
       '"birthday": "1984-01-01", "suffix": "Jr.", "nickname": "nick", ' \
       '"company_name": "company", "job_title": "title", ' \
       '"manager_name": "manager", "office_location": "the office", ' \
-      '"picture_url": "", ' \
-      '"source": "", ' \
-      '"web_page": { "type": "", "url": "" }, ' \
       '"notes": "some notes", "emails": [' \
-        '{ "type": "work", "email": "given@work.example.com", "name": "" }, ' \
-        '{ "type": "home", "email": "given@home.example.com", "name": "" }], ' \
+        '{ "type": "work", "email": "given@work.example.com" }, ' \
+        '{ "type": "home", "email": "given@home.example.com" }], ' \
       '"im_addresses": [{ "type": "gtalk", "im_address": "given@gtalk.example.com" }],' \
       '"physical_addresses": [{ "format": "structured", "type": "work",' \
         '"street_address": "123 N West St", "postal_code": "12345+0987", "city": "Los Angeles", "state": "CA",' \
         '"country": "USA" }],' \
+      '"web_page": {}, ' \
       '"phone_numbers": [{ "type": "mobile", "number": "+1234567890" }], ' \
       '"web_pages": [{ "type": "profile", "url": "http://given.example.com" }],' \
       '"groups": [{"id": "di", "object": "dnwi", "account_id": "doiw", "name": "nfowie", "path": "fnien"}] ' \
@@ -56,11 +54,9 @@ describe Nylas::Contact do
       expected_payload = JSON.dump(given_name: "Given",
                                    birthday: "2017-01-01",
                                    emails: [{ type: "work",
-                                              email: "given@other-job.example.com",
-                                              name: "" },
+                                              email: "given@other-job.example.com" },
                                             { type: "home",
-                                              email: "given@other-home.example.com",
-                                              name: "" }])
+                                              email: "given@other-home.example.com" }])
       expect(request[:method]).to be :put
       expect(request[:path]).to eql "/contacts/1234"
       expect(request[:payload]).to eql(expected_payload)
@@ -121,11 +117,9 @@ describe Nylas::Contact do
                                   birthday: "1984-01-01",
                                   company_name: "company",
                                   notes: "some notes",
-                                  picture_url: "",
-                                  source: "",
-                                  web_page: { type: "", url: "" },
-                                  emails: [{ type: "work", email: "given@work.example.com", name: "" },
-                                           { type: "home", email: "given@home.example.com", name: "" }],
+                                  web_page: {},
+                                  emails: [{ type: "work", email: "given@work.example.com" },
+                                           { type: "home", email: "given@home.example.com" }],
                                   im_addresses: [{ type: "gtalk", im_address: "given@gtalk.example.com" }],
                                   phone_numbers: [{ type: "mobile", number: "+1234567890" }],
                                   physical_addresses: [{ format: "structured", type: "work",
@@ -151,15 +145,12 @@ describe Nylas::Contact do
                                   manager_name: "manager",
                                   birthday: "1984-01-01",
                                   company_name: "company",
-                                  picture_url: "",
-                                  source: "",
-                                  web_page: "",
                                   emails: [],
                                   groups: [],
                                   im_addresses: [],
-                                  notes: "",
-                                  web_pages: [],
                                   phone_numbers: [],
+                                  web_page: {},
+                                  web_pages: [],
                                   physical_addresses: [{ format: "structured", type: "work",
                                                          street_address: "123 N West St",
                                                          postal_code: "", city: "", state: "",

--- a/spec/nylas/contact_spec.rb
+++ b/spec/nylas/contact_spec.rb
@@ -14,7 +14,6 @@ describe Nylas::Contact do
       '"physical_addresses": [{ "format": "structured", "type": "work",' \
         '"street_address": "123 N West St", "postal_code": "12345+0987", "city": "Los Angeles", "state": "CA",' \
         '"country": "USA" }],' \
-      '"web_page": {}, ' \
       '"phone_numbers": [{ "type": "mobile", "number": "+1234567890" }], ' \
       '"web_pages": [{ "type": "profile", "url": "http://given.example.com" }],' \
       '"groups": [{"id": "di", "object": "dnwi", "account_id": "doiw", "name": "nfowie", "path": "fnien"}] ' \
@@ -117,7 +116,6 @@ describe Nylas::Contact do
                                   birthday: "1984-01-01",
                                   company_name: "company",
                                   notes: "some notes",
-                                  web_page: {},
                                   emails: [{ type: "work", email: "given@work.example.com" },
                                            { type: "home", email: "given@home.example.com" }],
                                   im_addresses: [{ type: "gtalk", im_address: "given@gtalk.example.com" }],
@@ -149,7 +147,6 @@ describe Nylas::Contact do
                                   groups: [],
                                   im_addresses: [],
                                   phone_numbers: [],
-                                  web_page: {},
                                   web_pages: [],
                                   physical_addresses: [{ format: "structured", type: "work",
                                                          street_address: "123 N West St",

--- a/spec/nylas/contact_spec.rb
+++ b/spec/nylas/contact_spec.rb
@@ -7,9 +7,12 @@ describe Nylas::Contact do
       '"birthday": "1984-01-01", "suffix": "Jr.", "nickname": "nick", ' \
       '"company_name": "company", "job_title": "title", ' \
       '"manager_name": "manager", "office_location": "the office", ' \
+      '"picture_url": "", ' \
+      '"source": "", ' \
+      '"web_page": { "type": "", "url": "" }, ' \
       '"notes": "some notes", "emails": [' \
-        '{ "type": "work", "email": "given@work.example.com" }, ' \
-        '{ "type": "home", "email": "given@home.example.com" }], ' \
+        '{ "type": "work", "email": "given@work.example.com", "name": "" }, ' \
+        '{ "type": "home", "email": "given@home.example.com", "name": "" }], ' \
       '"im_addresses": [{ "type": "gtalk", "im_address": "given@gtalk.example.com" }],' \
       '"physical_addresses": [{ "format": "structured", "type": "work",' \
         '"street_address": "123 N West St", "postal_code": "12345+0987", "city": "Los Angeles", "state": "CA",' \
@@ -53,9 +56,11 @@ describe Nylas::Contact do
       expected_payload = JSON.dump(given_name: "Given",
                                    birthday: "2017-01-01",
                                    emails: [{ type: "work",
-                                              email: "given@other-job.example.com" },
+                                              email: "given@other-job.example.com",
+                                              name: "" },
                                             { type: "home",
-                                              email: "given@other-home.example.com" }])
+                                              email: "given@other-home.example.com",
+                                              name: "" }])
       expect(request[:method]).to be :put
       expect(request[:path]).to eql "/contacts/1234"
       expect(request[:payload]).to eql(expected_payload)
@@ -116,8 +121,11 @@ describe Nylas::Contact do
                                   birthday: "1984-01-01",
                                   company_name: "company",
                                   notes: "some notes",
-                                  emails: [{ type: "work", email: "given@work.example.com" },
-                                           { type: "home", email: "given@home.example.com" }],
+                                  picture_url: "",
+                                  source: "",
+                                  web_page: { type: "", url: "" },
+                                  emails: [{ type: "work", email: "given@work.example.com", name: "" },
+                                           { type: "home", email: "given@home.example.com", name: "" }],
                                   im_addresses: [{ type: "gtalk", im_address: "given@gtalk.example.com" }],
                                   phone_numbers: [{ type: "mobile", number: "+1234567890" }],
                                   physical_addresses: [{ format: "structured", type: "work",
@@ -143,6 +151,15 @@ describe Nylas::Contact do
                                   manager_name: "manager",
                                   birthday: "1984-01-01",
                                   company_name: "company",
+                                  picture_url: "",
+                                  source: "",
+                                  web_page: "",
+                                  emails: [],
+                                  groups: [],
+                                  im_addresses: [],
+                                  notes: "",
+                                  web_pages: [],
+                                  phone_numbers: [],
                                   physical_addresses: [{ format: "structured", type: "work",
                                                          street_address: "123 N West St",
                                                          postal_code: "", city: "", state: "",

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -35,12 +35,8 @@ describe Nylas::Draft do
                                      .and_return(id: "draft-1234", version: "6")
 
       draft.send!
-
-      expect(api).to have_received(:execute).with(method: :put, path: "/drafts/#{draft.id}",
-                                                  payload: update_json)
       expect(api).to have_received(:execute).with(method: :post, path: "/send",
-                                                  payload: JSON.dump(draft_id: draft.id,
-                                                                     version: draft.version))
+                                                  payload: update_json)
     end
   end
 

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -1,8 +1,6 @@
 describe Nylas::Message do
-  describe ".from_json" do
-    it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API)
-      data = { id: "mess-8766", object: "message", account_id: "acc-1234", thread_id: "thread-1234",
+  let(:data) do
+    data = { id: "mess-8766", object: "message", account_id: "acc-1234", thread_id: "thread-1234",
                date: 1_511_302_748,
                to: [{ email: "to@example.com", name: "To Example" }],
                from: [{ email: "from@example.com", name: "From Example" }],
@@ -29,6 +27,11 @@ describe Nylas::Message do
                folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
                labels: [{ display_name: "Inbox", id: "label-inbox", name: "inbox" },
                         { display_name: "All Mail", id: "label-all", name: "all" }] }
+  end
+
+  describe ".from_json" do
+    it "Deserializes all the attributes into Ruby objects" do
+      api = instance_double(Nylas::API)
 
       message = described_class.from_json(JSON.dump(data), api: api)
       expect(message.id).to eql "mess-8766"
@@ -111,6 +114,17 @@ describe Nylas::Message do
       expect(message.labels[1].display_name).to eql "All Mail"
       expect(message.labels[1].id).to eql "label-all"
       expect(message.labels[1].name).to eql "all"
+    end
+  end
+
+  describe '#serialize' do
+    it 'serializes labels correctly' do
+      api = instance_double(Nylas::API)
+      message = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(
+        JSON.parse(message.attributes.serialize)['labels']
+      ).to match_array(%w(label-inbox label-all))
     end
   end
 


### PR DESCRIPTION
Add `address` attribute to `physical_address` to support unstructured addresses, which occur in Google when `street_address` is missing.

Also rebased with original repo to add sending timeouts.
https://github.com/nylas/nylas-ruby/commit/09e2b4397dc2385974307ce21843a5f40a64fa32