### PR TITLE
Add address to physical address + Update to v4.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,14 @@
 Gemfile.lock
 gemfiles/*.lock
 InstalledFiles
+.idea/
 _yardoc
 coverage
 doc/
 lib/bundler/man
 pkg
 rdoc
+.ruby-version
 spec/reports
 test/tmp
 test/version_tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,12 @@
 require: rubocop-rspec
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
   DisplayStyleGuide: true
   Exclude:
     - examples/**/*
+    - vendor/**/*
+    - gemfiles/vendor/**/*
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Metrics/BlockLength:
     - "*.gemspec"
     - "spec/**/*_spec.rb"
 
+Metrics/ParameterLists:
+  Max: 8
+
 Naming/FileName:
   Exclude:
     - "lib/nylas-streaming.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
  - 2.6
 cache: bundler
 gemfile:
-  - gemfiles/Gemfile.rails4
   - gemfiles/Gemfile.rails5
   - gemfiles/Gemfile.rest-client.1
   - gemfiles/Gemfile.rest-client.2
@@ -23,6 +22,12 @@ env:
 
 matrix:
   include:
+  - rvm: 2.4
+    gemfile: gemfiles/Gemfile.rails4
+    before_install:
+    - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+    - gem install bundler -v '< 2'
+
   - name: "RuboCop"
     rvm: 2.6
     gemfile: gemfiles/Gemfile.rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: ruby
 rvm:
- - 2.2
- - 2.3
  - 2.4
+ - 2.5
+ - 2.6
 cache: bundler
 gemfile:
   - gemfiles/Gemfile.rails4
   - gemfiles/Gemfile.rails5
   - gemfiles/Gemfile.rest-client.1
   - gemfiles/Gemfile.rest-client.2
+
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,12 @@ after_script:
 env:
   global:
     - CC_TEST_REPORTER_ID=d6eceb65e7832b7989705fe162ec290d311d9d37e4e1a653f30ad957a683253a
+
+matrix:
+  include:
+  - name: "RuboCop"
+    rvm: 2.6
+    gemfile: gemfiles/Gemfile.rubocop
+    before_script: skip
+    script: bundle exec rubocop --config .rubocop.yml
+    after_script: skip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Unreleased
 * Drop support for Ruby 2.2 and 2.3: they have reached end-of-life
 * Add support for Ruby 2.5 and 2.6
+* Add `scopes` argument to `Nylas::API#authenticate` for
+  [selective sync](https://docs.nylas.com/docs/how-to-use-selective-sync)
 
 ### 4.2.4 / 2018-08-07
 * Enables silent addition of fields to API without impact to SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ### Unreleased
 
-nothing yet
-
-### 4.3.0 / 2019-03-15
 * Drop support for Ruby 2.2 and 2.3: they have reached end-of-life
 * Add support for Ruby 2.5 and 2.6
 * Add `scopes` argument to `Nylas::API#authenticate` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ nothing yet
 * Add `scopes` argument to `Nylas::API#authenticate` for
   [selective sync](https://docs.nylas.com/docs/how-to-use-selective-sync)
 * Add `Account#revoke_all`
+* Add X-Nylas-Client-Id header for HTTP requests
 
 ### 4.2.4 / 2018-08-07
 * Enables silent addition of fields to API without impact to SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### Unreleased
+
+nothing yet
+
+### 4.3.0 / 2019-03-15
 * Drop support for Ruby 2.2 and 2.3: they have reached end-of-life
 * Add support for Ruby 2.5 and 2.6
 * Add `scopes` argument to `Nylas::API#authenticate` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+* Drop support for Ruby 2.2 and 2.3: they have reached end-of-life
+* Add support for Ruby 2.5 and 2.6
+
 ### 4.2.4 / 2018-08-07
 * Enables silent addition of fields to API without impact to SDK
 * Fixes api attribute breakage on enumeration (https://github.com/nylas/nylas-ruby/issues/188)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add support for Ruby 2.5 and 2.6
 * Add `scopes` argument to `Nylas::API#authenticate` for
   [selective sync](https://docs.nylas.com/docs/how-to-use-selective-sync)
+* Add `Account#revoke_all`
 
 ### 4.2.4 / 2018-08-07
 * Enables silent addition of fields to API without impact to SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+nothing yet
+
+### 4.3.0 / 2019-03-18
+
 * Drop support for Ruby 2.2 and 2.3: they have reached end-of-life
 * Add support for Ruby 2.5 and 2.6
 * Add `scopes` argument to `Nylas::API#authenticate` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Unreleased
 
-nothing yet
+* Add optional argument for `Model#to_json`
 
 ### 4.3.0 / 2019-03-18
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec name: "nylas-streaming"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ api.authenticate(
 )
 ```
 
+If you do not pass any scopes, then the SDK will default to using all of them.
+
 ### Handling Errors
 The Nylas API uses conventional HTTP response codes to indicate success or failure of an API request. The ruby gem raises these as native exceptions.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ We support Rails 4.2 and above. A more detailed compatibility list can be found 
 
 Examples are located in the [examples](./examples) directory. Examples in plain ruby are in [examples/plain-ruby/](./examples/plain-ruby). They are grouped by the API endpoints they interact with.
 
+## Scopes
+
+The Nylas API allows you to set various scopes during the authentication process
+in order to use the [Selective Sync](https://docs.nylas.com/docs/how-to-use-selective-sync)
+feature. Currently, these scopes are `email`, `calendar`, and `contacts`.
+You can pass an array of scopes to `Nylas::API#authenticate`, like this:
+
+```ruby
+api = Nylas::API.new()
+api.authenticate(
+    name: 'fake',
+    email_address: 'fake@example.com',
+    provider: :gmail,
+    settings: {},
+    scopes: ["email"]
+)
+```
+
 ### Handling Errors
 The Nylas API uses conventional HTTP response codes to indicate success or failure of an API request. The ruby gem raises these as native exceptions.
 

--- a/bin/rspec
+++ b/bin/rspec
@@ -8,7 +8,7 @@
 # this file is here to facilitate running it.
 #
 
-bundle_binstub = File.expand_path("../bundle", __FILE__)
+bundle_binstub = File.expand_path("bundle", __dir__)
 load(bundle_binstub) if File.file?(bundle_binstub)
 
 require "pathname"

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -8,7 +8,7 @@
 # this file is here to facilitate running it.
 #
 
-bundle_binstub = File.expand_path("../bundle", __FILE__)
+bundle_binstub = File.expand_path("bundle", __dir__)
 load(bundle_binstub) if File.file?(bundle_binstub)
 
 require "pathname"

--- a/bin/yard
+++ b/bin/yard
@@ -8,7 +8,7 @@
 # this file is here to facilitate running it.
 #
 
-bundle_binstub = File.expand_path("../bundle", __FILE__)
+bundle_binstub = File.expand_path("bundle", __dir__)
 load(bundle_binstub) if File.file?(bundle_binstub)
 
 require "pathname"

--- a/bin/yardoc
+++ b/bin/yardoc
@@ -8,7 +8,7 @@
 # this file is here to facilitate running it.
 #
 
-bundle_binstub = File.expand_path("../bundle", __FILE__)
+bundle_binstub = File.expand_path("bundle", __dir__)
 load(bundle_binstub) if File.file?(bundle_binstub)
 
 require "pathname"

--- a/bin/yri
+++ b/bin/yri
@@ -8,7 +8,7 @@
 # this file is here to facilitate running it.
 #
 
-bundle_binstub = File.expand_path("../bundle", __FILE__)
+bundle_binstub = File.expand_path("bundle", __dir__)
 load(bundle_binstub) if File.file?(bundle_binstub)
 
 require "pathname"

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "./lib/nylas/version"
 
 # Consistently apply nylas' standard gem data across gems
@@ -23,12 +25,12 @@ module GemConfig
 
   def self.metadata
     {
-      "bug_tracker_uri"   => "https://github.com/nylas/nylas-ruby/issues",
-      "changelog_uri"     => "https://github.com/nylas/nylas-ruby/blob/master/CHANGELOG.md",
+      "bug_tracker_uri" => "https://github.com/nylas/nylas-ruby/issues",
+      "changelog_uri" => "https://github.com/nylas/nylas-ruby/blob/master/CHANGELOG.md",
       "documentation_uri" => "http://www.rubydoc.info/gems/nylas",
-      "homepage_uri"      => "https://www.nylas.com",
-      "source_code_uri"   => "https://github.com/nylas/nylas-ruby",
-      "wiki_uri"          => "https://github.com/nylas/nylas-ruby/wiki"
+      "homepage_uri" => "https://www.nylas.com",
+      "source_code_uri" => "https://github.com/nylas/nylas-ruby",
+      "wiki_uri" => "https://github.com/nylas/nylas-ruby/wiki"
     }
   end
 

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -47,6 +47,7 @@ module GemConfig
      ["pry-nav", "~> 0.2.4"],
      ["pry-stack_explorer", "~> 0.4.9"],
      ["rspec", "~> 3.7"],
+     ["rspec-json_matcher", "~> 0.1"],
      ["webmock", "~> 3.0"],
      ["faker", "~> 1.8"],
      ["informed", "~> 1.0"],

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -8,7 +8,7 @@ module GemConfig
     gem.license = "MIT"
     gem.version = Nylas::VERSION
     gem.platform = "ruby"
-    gem.required_ruby_version = "~> 2.2"
+    gem.required_ruby_version = ">= 2.4"
     append_nylas_data(gem)
     dev_dependencies.each do |dependency|
       gem.add_development_dependency(*dependency)
@@ -33,7 +33,7 @@ module GemConfig
   end
 
   def self.dev_dependencies
-    [["bundler", "~> 1.3"],
+    [["bundler", ">= 1.3.0"],
      ["jeweler", "~> 2.1"],
      ["yard", "~> 0.9.0"],
      ["awesome_print", "~> 1.0"],

--- a/gemfiles/Gemfile.rubocop
+++ b/gemfiles/Gemfile.rubocop
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rubocop'
+gem 'rubocop-rspec'

--- a/lib/nylas-streaming.rb
+++ b/lib/nylas-streaming.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "yajl"
 require "em-http"
 require "nylas"
@@ -72,6 +74,7 @@ module Nylas
 
       def parser
         return @parser if @parser
+
         @parser = Yajl::Parser.new(symbolize_keys: true)
         @parser
       end

--- a/lib/nylas-streaming.rb
+++ b/lib/nylas-streaming.rb
@@ -25,7 +25,6 @@ module Nylas
       # @param include_types [Array<String>] List of Object types to exclusively include in the stream
       # @param connect_timeout [Integer] How long to wait before timing out on attempted connection
       # @param inactivity_timeout [Integer] How long to wait before timing out on inactivity
-      # rubocop:disable Metrics/ParameterLists
       def initialize(cursor:, api:, exclude_types: [], include_types: [], expanded: false, connect_timeout: 0,
                      inactivity_timeout: 0)
         self.cursor = cursor
@@ -36,7 +35,6 @@ module Nylas
         self.connect_timeout = connect_timeout
         self.inactivity_timeout = inactivity_timeout
       end
-      # rubocop:enable Metrics/ParameterLists
 
       def stream
         parser.on_parse_complete = lambda do |data|

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "json"
 require "rest-client"
 

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -24,6 +24,11 @@ module Nylas
       response[:success]
     end
 
+    def revoke_all
+      response = execute(method: :post, path: "#{resource_path}/revoke-all")
+      response[:success]
+    end
+
     def self.resources_path(api:)
       "/a/#{api.app_id}/accounts"
     end

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -24,8 +24,10 @@ module Nylas
       response[:success]
     end
 
-    def revoke_all
-      response = execute(method: :post, path: "#{resource_path}/revoke-all")
+    def revoke_all(keep_access_token: nil)
+      payload = JSON.dump(keep_access_token: keep_access_token) if keep_access_token
+
+      response = execute(method: :post, path: "#{resource_path}/revoke-all", payload: payload)
       response[:success]
     end
 

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Representation of the accounts for Account management purposes.
   # @see https://docs.nylas.com/reference#account-management

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -25,10 +25,15 @@ module Nylas
     # rubocop:enable Metrics/ParameterLists
 
     # @return [String] A Nylas access token for that particular user.
-    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil)
-      NativeAuthentication.new(api: self).authenticate(name: name, email_address: email_address,
-                                                       provider: provider, settings: settings,
-                                                       reauth_account_id: reauth_account_id)
+    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil, scopes: nil)
+      NativeAuthentication.new(api: self).authenticate(
+        name: name,
+        email_address: email_address,
+        provider: provider,
+        settings: settings,
+        reauth_account_id: reauth_account_id,
+        scopes: scopes,
+      )
     end
 
     # @return [Collection<Contact>] A queryable collection of Contacts

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -17,14 +17,12 @@ module Nylas
     #                            you're using a self-hosted Nylas instance.
     # @param service_domain [String] (Optional) Host you are authenticating OAuth against.
     # @return [Nylas::API]
-    # rubocop:disable Metrics/ParameterLists
     def initialize(client: nil, app_id: nil, app_secret: nil, access_token: nil,
                    api_server: "https://api.nylas.com", service_domain: "api.nylas.com")
       self.client = client || HttpClient.new(app_id: app_id, app_secret: app_secret,
                                              access_token: access_token, api_server: api_server,
                                              service_domain: service_domain)
     end
-    # rubocop:enable Metrics/ParameterLists
 
     # @return [String] A Nylas access token for that particular user.
     def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil, scopes: nil)
@@ -126,7 +124,9 @@ module Nylas
       @webhooks ||= Collection.new(model: Webhook, api: as(client.app_secret))
     end
 
-    private def prevent_calling_if_missing_access_token(method_name)
+    private
+
+    def prevent_calling_if_missing_access_token(method_name)
       return if client.access_token && !client.access_token.empty?
 
       raise NoAuthToken, method_name

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -99,6 +99,14 @@ module Nylas
       response.code == 200 && response.empty?
     end
 
+    # Returns list of IP addresses
+    # @return [Hash]
+    # hash has keys of :updated_at (unix timestamp) and :ip_addresses (array of strings)
+    def ip_addresses
+      path = "/a/#{app_id}/ip_addresses"
+      client.as(client.app_secret).get(path: path)
+    end
+
     # @param message [Hash, String, #send!]
     # @return [Message] The resulting message
     def send!(message)

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Methods to retrieve data from the Nylas API as Ruby objects
   class API
@@ -32,7 +34,7 @@ module Nylas
         provider: provider,
         settings: settings,
         reauth_account_id: reauth_account_id,
-        scopes: scopes,
+        scopes: scopes
       )
     end
 
@@ -126,6 +128,7 @@ module Nylas
 
     private def prevent_calling_if_missing_access_token(method_name)
       return if client.access_token && !client.access_token.empty?
+
       raise NoAuthToken, method_name
     end
   end

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Ruby bindings for the Nylas Calendar API
   # @see https://docs.nylas.com/reference#calendars

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # An enumerable for working with index and search endpoints
   class Collection
@@ -27,11 +29,13 @@ module Nylas
     # @return [Collection<Model>]
     def where(filters)
       raise ModelNotFilterableError, model unless model.filterable?
+
       self.class.new(model: model, api: api, constraints: constraints.merge(where: filters))
     end
 
     def search(query)
       raise ModelNotSearchableError, model unless model.searchable?
+
       SearchCollection.new(model: model, api: api, constraints: constraints.merge(where: { q: query }))
     end
 
@@ -40,6 +44,7 @@ module Nylas
     # @return [Collection<String>]
     def raw
       raise ModelNotAvailableAsRawError, model unless model.exposable_as_raw?
+
       self.class.new(model: model, api: api, constraints: constraints.merge(accept: model.raw_mime_type))
     end
 
@@ -61,6 +66,7 @@ module Nylas
     # Iterates over a single page of results based upon current pagination settings
     def each
       return enum_for(:each) unless block_given?
+
       execute.each do |result|
         yield(model.new(result.merge(api: api)))
       end
@@ -77,6 +83,7 @@ module Nylas
     # Iterates over every result that meets the filters, retrieving a page at a time
     def find_each
       return enum_for(:find_each) unless block_given?
+
       query = self
       accumulated = 0
 
@@ -92,6 +99,7 @@ module Nylas
 
     def next_page(accumulated:, current_page:)
       return nil unless more_pages?(accumulated, current_page)
+
       self.class.new(model: model, api: api, constraints: constraints.next_page)
     end
 
@@ -99,6 +107,7 @@ module Nylas
       return false if current_page.empty?
       return false if constraints.limit && accumulated >= constraints.limit
       return false if constraints.per_page && current_page.length < constraints.per_page
+
       true
     end
 

--- a/lib/nylas/constraints.rb
+++ b/lib/nylas/constraints.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # The constraints a particular GET request will include in their query params
   class Constraints
@@ -48,6 +50,7 @@ module Nylas
       return constraints if constraints.is_a?(Constraints)
       return new(**constraints) if constraints.respond_to?(:key?)
       return new if constraints.nil?
+
       raise TypeError, "passed in constraints #{constraints} cannot be cast to a set of constraints"
     end
   end

--- a/lib/nylas/constraints.rb
+++ b/lib/nylas/constraints.rb
@@ -4,7 +4,6 @@ module Nylas
   # The constraints a particular GET request will include in their query params
   class Constraints
     attr_accessor :where, :limit, :offset, :view, :per_page, :accept
-    # rubocop:disable Metrics/ParameterLists
     def initialize(where: {}, limit: nil, offset: 0, view: nil, per_page: 100, accept: "application/json")
       self.where = where
       self.limit = limit
@@ -22,7 +21,6 @@ module Nylas
                       view: view || self.view,
                       accept: accept || self.accept)
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def next_page
       merge(offset: offset + per_page)

--- a/lib/nylas/contact.rb
+++ b/lib/nylas/contact.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # ActiveModel compliant interface for interacting with the Contacts API
   # @see https://docs.nylas.com/reference#contacts
@@ -40,6 +42,7 @@ module Nylas
     # to retrieve it from nylas every time.
     def picture
       return @picture_tempfile if @picture_tempfile
+
       @picture_tempfile = Tempfile.new
       @picture_tempfile.write(api.get(path: "#{resource_path}/picture"))
       @picture_tempfile.close

--- a/lib/nylas/contact_group.rb
+++ b/lib/nylas/contact_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the Contact Group schema
   # @see https://docs.nylas.com/reference#contactsid

--- a/lib/nylas/current_account.rb
+++ b/lib/nylas/current_account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Ruby representation of the Nylas /account API
   # @see https://docs.nylas.com/reference#account

--- a/lib/nylas/delta.rb
+++ b/lib/nylas/delta.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Ruby object to represent a single change. Used both when receiving a webhook, as well as the deltas API.
   # @see https://docs.nylas.com/reference#receiving-notifications
@@ -18,6 +20,7 @@ module Nylas
 
     def model
       return nil if object.nil?
+
       @model ||= Types.registry[object.to_sym].cast(object_attributes_with_ids)
     end
 

--- a/lib/nylas/deltas.rb
+++ b/lib/nylas/deltas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Ruby object to represent a collection of changes. Used both when receiving a webhook, as well as the
   # deltas API.

--- a/lib/nylas/deltas_collection.rb
+++ b/lib/nylas/deltas_collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Special collection for delta objects
   class DeltasCollection < Collection
@@ -24,6 +26,7 @@ module Nylas
 
     def next_page(*)
       return nil if empty?
+
       where(cursor: cursor_end)
     end
 

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Ruby representatin of a Nylas Draft object
   # @see https://docs.nylas.com/reference#drafts

--- a/lib/nylas/email_address.rb
+++ b/lib/nylas/email_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the Email Address Schema
   # @see https://docs.nylas.com/reference#contactsid

--- a/lib/nylas/errors.rb
+++ b/lib/nylas/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   Error = Class.new(::StandardError)
 

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent a the Event Schema.
   # @see https://docs.nylas.com/reference#events

--- a/lib/nylas/event_collection.rb
+++ b/lib/nylas/event_collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Syntactical sugar methods for some of the Event's filters
   # @see https://docs.nylas.com/reference#get-events

--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -51,7 +51,9 @@ module Nylas
       true
     end
 
-    private def retrieve_file
+    private
+
+    def retrieve_file
       response = api.get(path: "#{resource_path}/download")
       filename = response.headers.fetch(:content_disposition, "").gsub("attachment; filename=", "")
       temp_file = Tempfile.new(filename)

--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent a the File Schema.
   # @see https://docs.nylas.com/reference#events
@@ -22,12 +24,14 @@ module Nylas
     # @return [Tempfile] - Local copy of the file
     def download
       return file if file
+
       self.file = retrieve_file
     end
 
     # Redownloads a file even if it's been cached. Closes and unlinks the tempfile to help memory usage.
     def download!
       return download if file.nil?
+
       file.close
       file.unlink
       self.file = nil
@@ -40,6 +44,7 @@ module Nylas
 
     def save
       raise ModelNotUpdatableError if persisted?
+
       response = api.execute(path: "/files", method: :post, headers: { multipart: true },
                              payload: { file: file })
       attributes.merge(response.first)

--- a/lib/nylas/folder.rb
+++ b/lib/nylas/folder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the Folder Schema
   # @see https://docs.nylas.com/reference#folders

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Plain HTTP client that can be used to interact with the Nylas API sans any type casting.
   class HttpClient
@@ -16,12 +18,12 @@ module Nylas
     }.freeze
 
     ENDPOINT_TIMEOUTS = {
-        "/oauth/authorize" => 345,
-        "/messages/search" => 350,
-        "/threads/search" => 350,
-        "/delta" => 3650,
-        "/delta/longpoll" => 3650,
-        "/delta/streaming" => 3650
+      "/oauth/authorize" => 345,
+      "/messages/search" => 350,
+      "/threads/search" => 350,
+      "/delta" => 3650,
+      "/delta/longpoll" => 3650,
+      "/delta/streaming" => 3650
     }.freeze
 
     include Logging
@@ -43,6 +45,7 @@ module Nylas
       unless api_server.include?("://")
         raise "When overriding the Nylas API server address, you must include https://"
       end
+
       @api_server = api_server
       @access_token = access_token
       @app_secret = app_secret
@@ -90,7 +93,6 @@ module Nylas
       resulting_headers = default_headers.merge(headers)
       { method: method, url: url, payload: payload, headers: resulting_headers, timeout: timeout }
     end
-    # rubocop:enable Metrics/ParameterLists
 
     # Syntactical sugar for making GET requests via the API.
     # @see #execute
@@ -115,7 +117,6 @@ module Nylas
     def delete(path: nil, payload: nil, headers: {}, query: {})
       execute(method: :delete, path: path, headers: headers, query: query, payload: payload)
     end
-    # rubocop:enable Metrics/ParameterList
 
     private def rest_client_execute(method:, url:, headers:, payload:, timeout:, &block)
       ::RestClient::Request.execute(method: method, url: url, payload: payload,
@@ -155,6 +156,7 @@ module Nylas
     private def handle_anticipated_failure_mode(http_code:, response:)
       return if http_code == 200
       return unless response.is_a?(Hash)
+
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
       raise exception.new(response[:type], response[:message], response.fetch(:server_error, nil))
     end

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -127,6 +127,7 @@ module Nylas
     def default_headers
       @default_headers ||= {
         "X-Nylas-API-Wrapper" => "ruby",
+        "X-Nylas-Client-Id" => @app_id,
         "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}",
         "Content-types" => "application/json"
       }

--- a/lib/nylas/im_address.rb
+++ b/lib/nylas/im_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the IM Address Schema
   # @see https://docs.nylas.com/reference#contactsid

--- a/lib/nylas/label.rb
+++ b/lib/nylas/label.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the Label Schema
   # @see https://docs.nylas.com/reference#labels

--- a/lib/nylas/logging.rb
+++ b/lib/nylas/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # We are explicitely choosing to allow clients to use or not use informed at their discretion
 # rubocop:disable Lint/HandleExceptions
 begin
@@ -20,6 +22,7 @@ module Nylas
 
     def self.logger
       return @logger if @logger
+
       @logger = Logger.new(STDOUT)
       @logger.level = level
       @logger

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Ruby representatin of a Nylas Message object
   # @see https://docs.nylas.com/reference#messages

--- a/lib/nylas/message_headers.rb
+++ b/lib/nylas/message_headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Translates message headers into a Ruby object
   # @see https://docs.nylas.com/reference#section-message-views

--- a/lib/nylas/message_tracking.rb
+++ b/lib/nylas/message_tracking.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Message tracking features
   # @see https://docs.nylas.com/reference#message-tracking-overview

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -77,7 +77,7 @@ module Nylas
     end
 
     # @return [String] JSON String of the model.
-    def to_json
+    def to_json(_opts = {})
       JSON.dump(to_h)
     end
 

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -87,7 +87,6 @@ module Nylas
                     :destroyable
       attr_writer :resources_path
 
-      # rubocop:disable Metrics/ParameterLists
       def allows_operations(creatable: false, showable: false, listable: false, filterable: false,
                             searchable: false, updatable: false, destroyable: false)
 
@@ -100,7 +99,6 @@ module Nylas
         self.destroyable ||= destroyable
       end
 
-      # rubocop:enable Metrics/ParameterLists
       def creatable?
         creatable
       end

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "model/attribute_definition"
 require_relative "model/list_attribute_definition"
 require_relative "model/attributable"
@@ -23,6 +25,7 @@ module Nylas
     def save
       result = if persisted?
                  raise ModelNotUpdatableError, self unless updatable?
+
                  execute(method: :put, payload: attributes.serialize, path: resource_path)
                else
                  create
@@ -40,11 +43,13 @@ module Nylas
 
     def create
       raise ModelNotCreatableError, self unless creatable?
+
       execute(method: :post, payload: attributes.serialize, path: resources_path)
     end
 
     def update(**data)
       raise ModelNotUpdatableError, model_class unless updatable?
+
       attributes.merge(**data)
       execute(method: :put, payload: attributes.serialize(keys: data.keys), path: resource_path)
       true
@@ -67,6 +72,7 @@ module Nylas
 
     def destroy
       raise ModelNotDestroyableError, self unless destroyable?
+
       execute(method: :delete, path: resource_path)
     end
 

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   module Model
     # Allows defining of tyypecastable attributes on a model

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -12,7 +12,7 @@ module Nylas
         assign(**initial_data)
       end
 
-      protected def assign(**data)
+      protected def assign(**data) # rubocop:disable Style/AccessModifierDeclarations
         data.each do |attribute_name, value|
           if respond_to?(:"#{attribute_name}=")
             send(:"#{attribute_name}=", value)

--- a/lib/nylas/model/attribute_definition.rb
+++ b/lib/nylas/model/attribute_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   module Model
     # Define a particular attribute for a given model

--- a/lib/nylas/model/attribute_definition.rb
+++ b/lib/nylas/model/attribute_definition.rb
@@ -13,7 +13,9 @@ module Nylas
         self.default = default
       end
 
-      private def type
+      private
+
+      def type
         Types.registry[type_name]
       end
     end

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   module Model
     # Stores the actual model data to allow for type casting and clean/dirty checking

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -19,12 +19,6 @@ module Nylas
         data[key] = cast(key, value)
       end
 
-      private def cast(key, value)
-        attribute_definitions[key].cast(value)
-      rescue TypeError => e
-        raise TypeError, "#{key} #{e.message}"
-      end
-
       # Merges data into the registry while casting input types correctly
       def merge(new_data)
         new_data.each do |attribute_name, value|
@@ -43,7 +37,15 @@ module Nylas
         JSON.dump(to_h(keys: keys))
       end
 
-      private def default_attributes
+      private
+
+      def cast(key, value)
+        attribute_definitions[key].cast(value)
+      rescue TypeError => e
+        raise TypeError, "#{key} #{e.message}"
+      end
+
+      def default_attributes
         attribute_definitions.keys.zip([]).to_h
       end
     end

--- a/lib/nylas/model/list_attribute_definition.rb
+++ b/lib/nylas/model/list_attribute_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   module Model
     # Allows models to have an attribute which is a lists of another type of thing
@@ -12,6 +14,7 @@ module Nylas
 
       def cast(list)
         return default if list.nil? || list.empty?
+
         list.map { |item| type.cast(item) }
       end
 

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -17,7 +17,7 @@ module Nylas
       exchange_code_for_access_token(code)
     end
 
-    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes: nil)
+    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes:)
       payload = { client_id: api.client.app_id, name: name, email_address: email_address,
                   provider: provider, settings: settings, scopes: scopes }
       payload[:reauth_account_id] = reauth_account_id

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -19,7 +19,9 @@ module Nylas
       exchange_code_for_access_token(code)
     end
 
-    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes:)
+    private
+
+    def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes:)
       payload = { client_id: api.client.app_id, name: name, email_address: email_address,
                   provider: provider, settings: settings, scopes: scopes }
       payload[:reauth_account_id] = reauth_account_id
@@ -27,7 +29,7 @@ module Nylas
       response[:code]
     end
 
-    private def exchange_code_for_access_token(code)
+    def exchange_code_for_access_token(code)
       payload = { client_id: api.client.app_id, client_secret: api.client.app_secret, code: code }
       response = api.execute(method: :post, path: "/connect/token", payload: JSON.dump(payload))
       response[:access_token]

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Authenticate your application using the native interface
   # @see https://docs.nylas.com/reference#native-authentication-1
@@ -9,7 +11,7 @@ module Nylas
 
     def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil,
                      scopes: nil)
-      scopes ||= ["email", "calendar", "contacts"]
+      scopes ||= %w[email calendar contacts]
       scopes = scopes.join(",") unless scopes.is_a?(String)
       code = retrieve_code(name: name, email_address: email_address, provider: provider,
                            settings: settings, reauth_account_id: reauth_account_id, scopes: scopes)

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -7,16 +7,19 @@ module Nylas
       self.api = api
     end
 
-    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil)
+    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil,
+                     scopes: nil)
+      scopes ||= ["email", "calendar", "contacts"]
+      scopes = scopes.join(",") unless scopes.is_a?(String)
       code = retrieve_code(name: name, email_address: email_address, provider: provider,
-                           settings: settings, reauth_account_id: reauth_account_id)
+                           settings: settings, reauth_account_id: reauth_account_id, scopes: scopes)
 
       exchange_code_for_access_token(code)
     end
 
-    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:)
+    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes: nil)
       payload = { client_id: api.client.app_id, name: name, email_address: email_address,
-                  provider: provider, settings: settings }
+                  provider: provider, settings: settings, scopes: scopes }
       payload[:reauth_account_id] = reauth_account_id
       response = api.execute(method: :post, path: "/connect/authorize", payload: JSON.dump(payload))
       response[:code]

--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Data structure for seending a message via the Nylas API
   class NewMessage

--- a/lib/nylas/nylas_date.rb
+++ b/lib/nylas/nylas_date.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent Nylas's more complex Date Schema
   # @see https://docs.nylas.com/reference#contactsid

--- a/lib/nylas/participant.rb
+++ b/lib/nylas/participant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the Participant
   class Participant

--- a/lib/nylas/phone_number.rb
+++ b/lib/nylas/phone_number.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the Phone Number Schema
   # @see https://docs.nylas.com/reference#contactsid

--- a/lib/nylas/physical_address.rb
+++ b/lib/nylas/physical_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the Physical Address schema
   # @see https://docs.nylas.com/reference#contactsid

--- a/lib/nylas/physical_address.rb
+++ b/lib/nylas/physical_address.rb
@@ -12,5 +12,6 @@ module Nylas
     attribute :state, :string
     attribute :city, :string
     attribute :country, :string
+    attribute :address, :string
   end
 end

--- a/lib/nylas/raw_message.rb
+++ b/lib/nylas/raw_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Allows sending of email with nylas from an rfc822 compatible string
   class RawMessage

--- a/lib/nylas/recurrence.rb
+++ b/lib/nylas/recurrence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Representation of a Recurrence object
   # @see https://docs.nylas.com/reference#section-recurrence

--- a/lib/nylas/registry.rb
+++ b/lib/nylas/registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Used to create a hash-like structure which defaults to raising an exception in the event the key to
   # retrieve does not exist.

--- a/lib/nylas/rsvp.rb
+++ b/lib/nylas/rsvp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Allows RSVPing to a particular event
   # @see https://docs.nylas.com/reference#rsvping-to-invitations

--- a/lib/nylas/search_collection.rb
+++ b/lib/nylas/search_collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Ensures our search requests hit the right path
   class SearchCollection < Collection

--- a/lib/nylas/thread.rb
+++ b/lib/nylas/thread.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Ruby representation of the Nylas /threads API
   # @see https://docs.nylas.com/reference#threads

--- a/lib/nylas/timespan.rb
+++ b/lib/nylas/timespan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent a Nylas Timespan.
   # @see https://docs.nylas.com/reference#section-timespan

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Collection of attribute types
   module Types
@@ -34,6 +36,7 @@ module Nylas
         return model.new if value.nil?
         return value if already_cast?(value)
         return model.new(**actual_attributes(value)) if value.respond_to?(:key?)
+
         raise TypeError, "Unable to cast #{value} to a #{model}"
       end
 
@@ -74,6 +77,7 @@ module Nylas
         return Time.at(object.to_i) if object.is_a?(String)
         return Time.at(object) if object.is_a?(Numeric)
         return object.to_time if object.is_a?(Date)
+
         raise TypeError, "Unable to cast #{object} to Time"
       end
 
@@ -91,11 +95,13 @@ module Nylas
     class DateType < ValueType
       def cast(value)
         return nil if value.nil?
+
         Date.parse(value)
       end
 
       def serialize(value)
         return value.iso8601 if value.respond_to?(:iso8601)
+
         value
       end
     end
@@ -106,6 +112,7 @@ module Nylas
       # @param value [Object] Casts the passed in object to a string using #to_s
       def cast(value)
         return value if value.nil?
+
         value.to_s
       end
     end
@@ -116,6 +123,7 @@ module Nylas
       # @param value [Object] Casts the passed in object to an integer using to_i
       def cast(value)
         return nil if value.nil?
+
         value.to_i
       end
     end
@@ -128,6 +136,7 @@ module Nylas
         return nil if value.nil?
         return true if value == true
         return false if value == false
+
         raise TypeError, "#{value} must be either true or false"
       end
     end

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "4.3.0"
+  VERSION = "4.2.4"
 end

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "4.2.4"
+  VERSION = "4.3.0"
 end

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
-  VERSION = "4.2.4".freeze
+  VERSION = "4.2.4"
 end

--- a/lib/nylas/web_page.rb
+++ b/lib/nylas/web_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent the Web Page Schema
   # @see https://docs.nylas.com/reference#contactsid

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Represents a webhook attached to your application.
   # @see https://docs.nylas.com/reference#webhooks

--- a/nylas-streaming.gemspec
+++ b/nylas-streaming.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "./gem_config"
 
 Gem::Specification.new do |gem|

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "./gem_config"
 
 Gem::Specification.new do |gem|

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -59,7 +59,10 @@ describe Nylas::Account do
 
     expect(account.revoke_all(keep_access_token: access_token)).to be_truthy
 
-    expect(api).to have_received(:execute).with(method: :post, path: "/a/app-987/accounts/acc-1234/revoke-all",
-                                                payload: be_json("keep_access_token" => access_token))
+    expect(api).to have_received(:execute).with(
+      method: :post,
+      path: "/a/app-987/accounts/acc-1234/revoke-all",
+      payload: be_json("keep_access_token" => access_token)
+    )
   end
 end

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Nylas::Account do
   it "is not filterable" do
     expect(described_class).not_to be_filterable
@@ -53,7 +55,7 @@ describe Nylas::Account do
   it "can revoke all tokens" do
     api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
-    access_token = 'some_access_token'
+    access_token = "some_access_token"
 
     expect(account.revoke_all(keep_access_token: access_token)).to be_truthy
 

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -50,4 +50,13 @@ describe Nylas::Account do
     expect(api).to have_received(:execute).with(method: :post, path: "/a/app-987/accounts/acc-1234/upgrade",
                                                 payload: nil)
   end
+  it "can revoke all tokens" do
+    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    account = described_class.from_json('{ "id": "acc-1234" }', api: api)
+
+    expect(account.revoke_all).to be_truthy
+
+    expect(api).to have_received(:execute).with(method: :post, path: "/a/app-987/accounts/acc-1234/revoke-all",
+                                                payload: nil)
+  end
 end

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -58,6 +58,6 @@ describe Nylas::Account do
     expect(account.revoke_all(keep_access_token: access_token)).to be_truthy
 
     expect(api).to have_received(:execute).with(method: :post, path: "/a/app-987/accounts/acc-1234/revoke-all",
-                                                payload: JSON.dump(keep_access_token: access_token))
+                                                payload: be_json("keep_access_token" => access_token))
   end
 end

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -53,10 +53,11 @@ describe Nylas::Account do
   it "can revoke all tokens" do
     api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
+    access_token = 'some_access_token'
 
-    expect(account.revoke_all).to be_truthy
+    expect(account.revoke_all(keep_access_token: access_token)).to be_truthy
 
     expect(api).to have_received(:execute).with(method: :post, path: "/a/app-987/accounts/acc-1234/revoke-all",
-                                                payload: nil)
+                                                payload: JSON.dump(keep_access_token: access_token))
   end
 end

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -28,6 +28,7 @@ describe Nylas::API do
       expect(client.default_headers).to include("X-Nylas-Client-Id" => "not-real")
     end
   end
+
   describe "#execute" do
     it "builds the URL based upon the api_server it was initialized with"
     it "adds the nylas headers to the request"

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 # This spec is the only one that should have any webmock stuff going on, everything else should use the

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -20,6 +20,11 @@ describe Nylas::API do
                                                        "No access token was provided and the " \
                                                        "current_account method requires one"
     end
+
+    it "sets X-Nylas-Client-Id header" do
+      client = Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real")
+      expect(client.default_headers).to include("X-Nylas-Client-Id" => "not-real")
+    end
   end
   describe "#execute" do
     it "builds the URL based upon the api_server it was initialized with"

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -98,7 +98,10 @@ describe Nylas::Collection do
     it "returns collection count filtered by `where`" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
-        .with(method: :get, path: "/collection", query: { id: "1234", limit: 100, offset: 0, view: "count" }, headers: {})
+        .with(method: :get,
+              path: "/collection",
+              query: { id: "1234", limit: 100, offset: 0, view: "count" },
+              headers: {})
         .and_return(count: 1)
 
       expect(collection.where(id: "1234").count).to be 1

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Nylas::Collection do
@@ -87,19 +89,19 @@ describe Nylas::Collection do
     it "returns collection count" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
-        .with(method: :get, path: "/collection", query: { limit: 100, offset: 0, view: "count"}, headers: {})
+        .with(method: :get, path: "/collection", query: { limit: 100, offset: 0, view: "count" }, headers: {})
         .and_return(count: 1)
 
-      expect(collection.count).to eql 1
+      expect(collection.count).to be 1
     end
 
     it "returns collection count filtered by `where`" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
-        .with(method: :get, path: "/collection", query: { id: "1234", limit: 100, offset: 0, view: "count"}, headers: {})
+        .with(method: :get, path: "/collection", query: { id: "1234", limit: 100, offset: 0, view: "count" }, headers: {})
         .and_return(count: 1)
 
-      expect(collection.where(id: "1234").count).to eql 1
+      expect(collection.where(id: "1234").count).to be 1
     end
   end
 end

--- a/spec/nylas/contact_spec.rb
+++ b/spec/nylas/contact_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Nylas::Contact do
@@ -114,7 +116,7 @@ describe Nylas::Contact do
                                                          postal_code: "12345+0987", state: "CA",
                                                          country: "USA" }],
                                   web_pages: [{ type: "profile", url: "http://given.example.com" }],
-                                  groups: [{id: "di", object: "dnwi", account_id: "doiw", name: "nfowie", path: "fnien"}])
+                                  groups: [{ id: "di", object: "dnwi", account_id: "doiw", name: "nfowie", path: "fnien" }])
     end
   end
   describe "#to_json" do

--- a/spec/nylas/contact_spec.rb
+++ b/spec/nylas/contact_spec.rb
@@ -18,7 +18,8 @@ describe Nylas::Contact do
         '"country": "USA" }],' \
       '"phone_numbers": [{ "type": "mobile", "number": "+1234567890" }], ' \
       '"web_pages": [{ "type": "profile", "url": "http://given.example.com" }],' \
-      '"groups": [{"id": "di", "object": "dnwi", "account_id": "doiw", "name": "nfowie", "path": "fnien"}] ' \
+      '"groups": [{"id": "di", "object": "dnwi", "account_id": "doiw", ' \
+        '"name": "nfowie", "path": "fnien"}] ' \
     "}"
   end
   let(:api) { FakeAPI.new }
@@ -93,32 +94,35 @@ describe Nylas::Contact do
   describe "#to_h" do
     it "serializes attributes into a hash of primitives" do
       contact = described_class.from_json(full_json, api: api)
-      expect(contact.to_h).to eql(id: "1234",
-                                  object: "contact",
-                                  account_id: "12345",
-                                  given_name: "given",
-                                  middle_name: "middle",
-                                  surname: "surname",
-                                  suffix: "Jr.",
-                                  nickname: "nick",
-                                  job_title: "title",
-                                  office_location: "the office",
-                                  manager_name: "manager",
-                                  birthday: "1984-01-01",
-                                  company_name: "company",
-                                  notes: "some notes",
-                                  emails: [{ type: "work", email: "given@work.example.com" },
-                                           { type: "home", email: "given@home.example.com" }],
-                                  im_addresses: [{ type: "gtalk", im_address: "given@gtalk.example.com" }],
-                                  phone_numbers: [{ type: "mobile", number: "+1234567890" }],
-                                  physical_addresses: [{ format: "structured", type: "work",
-                                                         street_address: "123 N West St",
-                                                         postal_code: "12345+0987", state: "CA",
-                                                         country: "USA" }],
-                                  web_pages: [{ type: "profile", url: "http://given.example.com" }],
-                                  groups: [{ id: "di", object: "dnwi", account_id: "doiw", name: "nfowie", path: "fnien" }])
+      expect(contact.to_h).to eql(
+        id: "1234",
+        object: "contact",
+        account_id: "12345",
+        given_name: "given",
+        middle_name: "middle",
+        surname: "surname",
+        suffix: "Jr.",
+        nickname: "nick",
+        job_title: "title",
+        office_location: "the office",
+        manager_name: "manager",
+        birthday: "1984-01-01",
+        company_name: "company",
+        notes: "some notes",
+        emails: [{ type: "work", email: "given@work.example.com" },
+                 { type: "home", email: "given@home.example.com" }],
+        im_addresses: [{ type: "gtalk", im_address: "given@gtalk.example.com" }],
+        phone_numbers: [{ type: "mobile", number: "+1234567890" }],
+        physical_addresses: [{ format: "structured", type: "work",
+                               street_address: "123 N West St",
+                               postal_code: "12345+0987", state: "CA",
+                               country: "USA" }],
+        web_pages: [{ type: "profile", url: "http://given.example.com" }],
+        groups: [{ id: "di", object: "dnwi", account_id: "doiw", name: "nfowie", path: "fnien" }]
+      )
     end
   end
+
   describe "#to_json" do
     it "returns a string of JSON" do
       contact = described_class.from_json(full_json, api: api)

--- a/spec/nylas/current_account_spec.rb
+++ b/spec/nylas/current_account_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Nylas::CurrentAccount do

--- a/spec/nylas/deltas_collection_spec.rb
+++ b/spec/nylas/deltas_collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Nylas::DeltasCollection do

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Nylas::Deltas do
   it "safely inflates an account.running event" do
     data = { "deltas": [{ "date": 1_514_335_663, "object": "account", "type": "account.running",

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Nylas::Draft do

--- a/spec/nylas/folder_spec.rb
+++ b/spec/nylas/folder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Nylas::Folder do
   it "is not filterable" do
     expect(described_class).not_to be_filterable

--- a/spec/nylas/label_spec.rb
+++ b/spec/nylas/label_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Nylas::Label do
   it "is not filterable" do
     expect(described_class).not_to be_filterable

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Nylas::Message do
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do

--- a/spec/nylas/model_spec.rb
+++ b/spec/nylas/model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Nylas::Model do

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -26,7 +26,7 @@ describe Nylas::NativeAuthentication do
       ).to eql("fake-token")
     end
 
-    it "allows customizable scopes" do
+    it "allows arrays of one scope" do
       client = Nylas::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
@@ -47,6 +47,56 @@ describe Nylas::NativeAuthentication do
           provider: :gmail,
           settings: {},
           scopes: ["email"]
+        )
+      ).to eql("fake-token")
+    end
+
+    it "allows arrays of two scopes" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real",
+        access_token: "seriously-unreal"
+      )
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email,contacts")
+      ).and_return(code: 1234)
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+      ).and_return(access_token: "fake-token")
+      api = Nylas::API.new(client: client)
+
+      expect(
+        api.authenticate(
+          name: 'fake',
+          email_address: 'fake@example.com',
+          provider: :gmail,
+          settings: {},
+          scopes: ["email", "contacts"]
+        )
+      ).to eql("fake-token")
+    end
+
+    it "allows string scopes" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real",
+        access_token: "seriously-unreal"
+      )
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "calendar")
+      ).and_return(code: 1234)
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+      ).and_return(access_token: "fake-token")
+      api = Nylas::API.new(client: client)
+
+      expect(
+        api.authenticate(
+          name: 'fake',
+          email_address: 'fake@example.com',
+          provider: :gmail,
+          settings: {},
+          scopes: "calendar"
         )
       ).to eql("fake-token")
     end

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -2,6 +2,8 @@
 
 require "spec_helper"
 
+# rubocop:disable RSpec/MessageSpies
+
 describe Nylas::NativeAuthentication do
   describe "#authenticate" do
     it "sets all scopes by default" do
@@ -11,10 +13,12 @@ describe Nylas::NativeAuthentication do
         access_token: "seriously-unreal"
       )
       expect(client).to receive(:execute).with(
-        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email,calendar,contacts")
+        method: :post, path: "/connect/authorize",
+        payload: be_json_including("scopes" => "email,calendar,contacts")
       ).and_return(code: 1234)
       expect(client).to receive(:execute).with(
-        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+        method: :post, path: "/connect/token",
+        payload: be_json_including("code" => 1234)
       ).and_return(access_token: "fake-token")
       api = Nylas::API.new(client: client)
 
@@ -35,10 +39,12 @@ describe Nylas::NativeAuthentication do
         access_token: "seriously-unreal"
       )
       expect(client).to receive(:execute).with(
-        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email")
+        method: :post, path: "/connect/authorize",
+        payload: be_json_including("scopes" => "email")
       ).and_return(code: 1234)
       expect(client).to receive(:execute).with(
-        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+        method: :post, path: "/connect/token",
+        payload: be_json_including("code" => 1234)
       ).and_return(access_token: "fake-token")
       api = Nylas::API.new(client: client)
 
@@ -60,10 +66,12 @@ describe Nylas::NativeAuthentication do
         access_token: "seriously-unreal"
       )
       expect(client).to receive(:execute).with(
-        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email,contacts")
+        method: :post, path: "/connect/authorize",
+        payload: be_json_including("scopes" => "email,contacts")
       ).and_return(code: 1234)
       expect(client).to receive(:execute).with(
-        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+        method: :post, path: "/connect/token",
+        payload: be_json_including("code" => 1234)
       ).and_return(access_token: "fake-token")
       api = Nylas::API.new(client: client)
 
@@ -85,10 +93,12 @@ describe Nylas::NativeAuthentication do
         access_token: "seriously-unreal"
       )
       expect(client).to receive(:execute).with(
-        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "calendar")
+        method: :post, path: "/connect/authorize",
+        payload: be_json_including("scopes" => "calendar")
       ).and_return(code: 1234)
       expect(client).to receive(:execute).with(
-        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+        method: :post, path: "/connect/token",
+        payload: be_json_including("code" => 1234)
       ).and_return(access_token: "fake-token")
       api = Nylas::API.new(client: client)
 
@@ -104,3 +114,5 @@ describe Nylas::NativeAuthentication do
     end
   end
 end
+
+# rubocop:enable RSpec/MessageSpies

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+describe Nylas::NativeAuthentication do
+  describe "#authenticate" do
+    it "sets all scopes by default" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real",
+        access_token: "seriously-unreal"
+      )
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email,calendar,contacts")
+      ).and_return(code: 1234)
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+      ).and_return(access_token: "fake-token")
+      api = Nylas::API.new(client: client)
+
+      expect(
+        api.authenticate(
+          name: 'fake',
+          email_address: 'fake@example.com',
+          provider: :gmail,
+          settings: {}
+        )
+      ).to eql("fake-token")
+    end
+
+    it "allows customizable scopes" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real",
+        access_token: "seriously-unreal"
+      )
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email")
+      ).and_return(code: 1234)
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+      ).and_return(access_token: "fake-token")
+      api = Nylas::API.new(client: client)
+
+      expect(
+        api.authenticate(
+          name: 'fake',
+          email_address: 'fake@example.com',
+          provider: :gmail,
+          settings: {},
+          scopes: ["email"]
+        )
+      ).to eql("fake-token")
+    end
+  end
+end

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Nylas::NativeAuthentication do
@@ -18,8 +20,8 @@ describe Nylas::NativeAuthentication do
 
       expect(
         api.authenticate(
-          name: 'fake',
-          email_address: 'fake@example.com',
+          name: "fake",
+          email_address: "fake@example.com",
           provider: :gmail,
           settings: {}
         )
@@ -42,8 +44,8 @@ describe Nylas::NativeAuthentication do
 
       expect(
         api.authenticate(
-          name: 'fake',
-          email_address: 'fake@example.com',
+          name: "fake",
+          email_address: "fake@example.com",
           provider: :gmail,
           settings: {},
           scopes: ["email"]
@@ -67,11 +69,11 @@ describe Nylas::NativeAuthentication do
 
       expect(
         api.authenticate(
-          name: 'fake',
-          email_address: 'fake@example.com',
+          name: "fake",
+          email_address: "fake@example.com",
           provider: :gmail,
           settings: {},
-          scopes: ["email", "contacts"]
+          scopes: %w[email contacts]
         )
       ).to eql("fake-token")
     end
@@ -92,8 +94,8 @@ describe Nylas::NativeAuthentication do
 
       expect(
         api.authenticate(
-          name: 'fake',
-          email_address: 'fake@example.com',
+          name: "fake",
+          email_address: "fake@example.com",
           provider: :gmail,
           settings: {},
           scopes: "calendar"

--- a/spec/nylas/thread_spec.rb
+++ b/spec/nylas/thread_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Nylas::Thread do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "simplecov"
 SimpleCov.start
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ SimpleCov.start
 require "nylas"
 require "pry"
 require "webmock/rspec"
+require "rspec-json_matcher"
+
+RSpec.configuration.include RSpec::JsonMatcher
 
 class FakeAPI
   def execute(method:, path:, payload: nil)

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
Adds `address` to `physical_address` to support unstructured format, which occurs in Google when `street_address` is missing.

This PR is rebased with the original nylas-ruby repo, to add:
- Sending timeouts
- Add optional argument for Model#to_json
- `ip_addresses` method
- All changes listed in the changelog under v4.3.0 (https://github.com/starburstlabs/nylas-ruby/blob/add-address-to-physical-address/CHANGELOG.md)